### PR TITLE
“Speedup” and "slowdown" are dictionary words, and other edits.

### DIFF
--- a/src/build-configuration.md
+++ b/src/build-configuration.md
@@ -13,7 +13,7 @@ when you want high performance. This is most often done by specifying the
 [easy to overlook]: https://users.rust-lang.org/t/why-my-rust-program-is-so-slow/47764/5
 
 A release build typically runs *much* faster than a debug build. 10-100x
-speed-ups over debug builds are common!
+speedups over debug builds are common!
 
 Debug builds are the default. They are produced if you run `cargo build`,
 `cargo run`, or `rustc` without any additional options. Debug builds are good

--- a/src/general-tips.md
+++ b/src/general-tips.md
@@ -17,8 +17,8 @@ data structures, rather than low-level optimizations.
 [**Example 1**](https://github.com/rust-lang/rust/pull/53383/commits/5745597e6195fe0591737f242d02350001b6c590),
 [**Example 2**](https://github.com/rust-lang/rust/pull/54318/commits/154be2c98cf348de080ce951df3f73649e8bb1a6).
 
-Having said that, most optimizations result in small speed-ups. Although no
-single small speed-up is noticeable, they really add up if you can do enough of
+Having said that, most optimizations result in small speedups. Although no
+single small speedup is noticeable, they really add up if you can do enough of
 them.
 
 Different profilers have different strengths. It is good to use more than one.
@@ -28,7 +28,7 @@ speed things up: (a) make the function faster, and/or (b) avoid calling it as
 much.
 
 It is usually easier, and often as effective, to avoid silly slow-downs as it
-is to introduce clever speed-ups.
+is to introduce clever speedups.
 
 Avoid computing things unless necessary. Lazy/on-demand computations are
 often a win.

--- a/src/general-tips.md
+++ b/src/general-tips.md
@@ -27,7 +27,7 @@ When profiling indicates that a function is hot, there are two common ways to
 speed things up: (a) make the function faster, and/or (b) avoid calling it as
 much.
 
-It is usually easier, and often as effective, to avoid silly slow-downs as it
+It is usually easier, and often as effective, to avoid silly slowdowns as it
 is to introduce clever speedups.
 
 Avoid computing things unless necessary. Lazy/on-demand computations are

--- a/src/hashing.md
+++ b/src/hashing.md
@@ -29,7 +29,7 @@ If hashing performance is important in your program, it is worth trying more
 than one of these alternatives. For example, the following results were seen in
 rustc.
 - The switch from `fnv` to `fxhash` gave
-  [speed-ups of up to 6%](https://github.com/rust-lang/rust/pull/37229/commits/00e48affde2d349e3b3bfbd3d0f6afb5d76282a7).
+  [speedups of up to 6%](https://github.com/rust-lang/rust/pull/37229/commits/00e48affde2d349e3b3bfbd3d0f6afb5d76282a7).
 - An attempt to switch from `fxhash` to `ahash` resulted in
   [slow-downs of 1-4%](https://github.com/rust-lang/rust/issues/69153#issuecomment-589504301).
 - An attempt to switch from `fxhash` back to the default hasher resulted in

--- a/src/hashing.md
+++ b/src/hashing.md
@@ -31,9 +31,9 @@ rustc.
 - The switch from `fnv` to `fxhash` gave
   [speedups of up to 6%](https://github.com/rust-lang/rust/pull/37229/commits/00e48affde2d349e3b3bfbd3d0f6afb5d76282a7).
 - An attempt to switch from `fxhash` to `ahash` resulted in
-  [slow-downs of 1-4%](https://github.com/rust-lang/rust/issues/69153#issuecomment-589504301).
+  [slowdowns of 1-4%](https://github.com/rust-lang/rust/issues/69153#issuecomment-589504301).
 - An attempt to switch from `fxhash` back to the default hasher resulted in
-  [slow-downs ranging from 4-84%](https://github.com/rust-lang/rust/issues/69153#issuecomment-589338446)!
+  [slowdowns ranging from 4-84%](https://github.com/rust-lang/rust/issues/69153#issuecomment-589338446)!
 
 If you decide to universally use one of the alternatives, such as
 `FxHashSet`/`FxHashMap`, it is easy to accidentally use `HashSet`/`HashMap` in

--- a/src/iterators.md
+++ b/src/iterators.md
@@ -2,9 +2,9 @@
 
 ## `collect`
 
-[`Iterator::collect`] converts an iterator into a collection,`Vec`
+[`Iterator::collect`] converts an iterator into a collection, like `Vec`,
 which typically requires an allocation. You should avoid calling `collect` if
-the collection is then only iterated over again.
+the collection is later iterated over again.
 
 [`Iterator::collect`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.collect
 

--- a/src/iterators.md
+++ b/src/iterators.md
@@ -9,7 +9,7 @@ the collection is then only iterated over again.
 [`Iterator::collect`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.collect
 
 For this reason, it is often better to return an iterator type like `impl
-Iterator<Item=T>` from a function than a`Vec<T>`. Sometimes
+Iterator<Item=T>` from a function than a `Vec<T>`. Sometimes
 additional lifetimes are required on these return types, as [this post]
 explains.
 

--- a/src/iterators.md
+++ b/src/iterators.md
@@ -2,14 +2,14 @@
 
 ## `collect`
 
-[`Iterator::collect`] converts an iterator into a collection such as `Vec`,
+[`Iterator::collect`] converts an iterator into a collection,`Vec`
 which typically requires an allocation. You should avoid calling `collect` if
 the collection is then only iterated over again.
 
 [`Iterator::collect`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.collect
 
 For this reason, it is often better to return an iterator type like `impl
-Iterator<Item=T>` from a function than a `Vec<T>`. Note that sometimes
+Iterator<Item=T>` from a function than a`Vec<T>`. Sometimes
 additional lifetimes are required on these return types, as [this post]
 explains.
 

--- a/src/machine-code.md
+++ b/src/machine-code.md
@@ -1,12 +1,12 @@
 # Machine Code
 
-When you have a small piece of very hot code, it may be worth inspecting the
+When you have a small segment of very hot code, it may be worth inspecting the
 generated machine code to see if it has any inefficiencies. The [Compiler
 Explorer] website is an excellent resource when doing this.
 
 [Compiler Explorer]: https://godbolt.org/
 
-Relatedly, the [`core::arch`] module provides access to architecture-specific
+Also the [`core::arch`] module provides access to architecture-specific
 intrinsics, many of which relate to SIMD instructions.
 
 [`core::arch`]: https://doc.rust-lang.org/core/arch/index.html

--- a/src/profiling.md
+++ b/src/profiling.md
@@ -1,6 +1,5 @@
 ## Profilers
 
-
 When optimizing code, you also need a way to determine which parts of the
 program are hot and worth modifying. This is best done with a profiler. There
 are many profilers available, each with their strengths and
@@ -9,10 +8,6 @@ weaknesses.
 Here are some profilers that work with Rust.
 - [perf] is a versatile profiler that uses hardware performance counters.
   The [Hotspot] viewer is good for viewing data recorded by perf.
-=======
-When optimizing a program, you also need a way to determine which parts of the
-program are hot and worth modifying. This is best done via profiling.
-
 - [Cachegrind] & [Callgrind] give global, per-function, and per-source-line
 instruction counts and simulated cache and branch prediction data.
 - [DHAT] is good for finding which parts of the code are causing a lot of

--- a/src/profiling.md
+++ b/src/profiling.md
@@ -1,21 +1,20 @@
 # Profiling
 
-When optimizing a program, you also need a way to determine which parts of the
+When optimizing code, you also need a way to determine which parts of the
 program are hot and worth modifying. This is best done with a profiler. There
-are many different profilers available, each with their strengths and
+are many profilers available, each with their strengths and
 weaknesses.
 
-The following is an incomplete list of profilers that have been used
-successfully on Rust programs.
-- [perf] is a general-purpose profiler that uses hardware performance counters.
+Here are some profilers that work with Rust.
+- [perf] is a versatile profiler that uses hardware performance counters.
   The [Hotspot] viewer is good for viewing data recorded by perf.
 - [Cachegrind] & [Callgrind] give global, per-function, and per-source-line
-  instruction counts and simulated cache and branch prediction data.
+instruction counts and simulated cache and branch prediction data.
 - [DHAT] is good for finding which parts of the code are causing a lot of
-  allocations, and for giving insight into peak memory usage.
-- [`counts`] supports ad hoc profiling, which combines the use of `eprintln!`
-  statement with frequency-based post-processing, which is good for getting
-  domain-specific insights into parts of your code.
+allocations, and for giving insight into peak memory usage.
+- [`counts`] supports ad hoc profiling, which combines `eprintln!`
+  statement and frequency-based post-processing, which is good for getting
+domain-specific insights into your code.
 
 [perf]: https://perf.wiki.kernel.org/index.php/Main_Page
 [Hotspot]: https://github.com/KDAB/hotspot


### PR DESCRIPTION
If merged, this PR changes `speed-up` to `speedup` everywhere.

Ref:
* https://www.merriam-webster.com/dictionary/speedup and also 
* https://en.wikipedia.org/wiki/Speedup.