### PR TITLE
Document `format_args!`

### DIFF
--- a/src/heap-allocations.md
+++ b/src/heap-allocations.md
@@ -214,12 +214,15 @@ will avoid this allocation.
 
 Another way to avoid a `format!` call is to use `format_args!` which will
 produce `fmt::Arguments` that you can pass around without any allocations.
+It is often useful for formatting functions that take formatted arguments.
 ```rust
-// This involves only one allocation
-format!(
-    "{:?}",
-    format_args!("{} + {} = {}", 1, 2, format_args!("{}", 1 + 2))
-);
+use std::fmt;
+// Instead of taking `&str`, this takes `fmt::Arguments`
+// and the `format_args!` call below won't involve an allocation
+fn write_command(args: fmt::Arguments) {
+    println!("$ {}", args);
+}
+write_command(format_args!("cargo {}", "run"));
 ```
 
 ## Hash tables

--- a/src/heap-allocations.md
+++ b/src/heap-allocations.md
@@ -212,6 +212,16 @@ allocation. If you can avoid a `format!` call by using a string literal, that
 will avoid this allocation.
 [**Example**](https://github.com/rust-lang/rust/pull/55905/commits/c6862992d947331cd6556f765f6efbde0a709cf9).
 
+Another way to avoid a `format!` call is to use `format_args!` which will
+produce `fmt::Arguments` that you can pass around without any allocations.
+```rust
+// This involves only one allocation
+format!(
+    "{:?}",
+    format_args!("{} + {} = {}", 1, 2, format_args!("{}", 1 + 2))
+);
+```
+
 ## Hash tables
 
 [`HashSet`] and [`HashMap`] are hash tables. Their representation and


### PR DESCRIPTION
I thought this was worth mentioning because it essentially allows you to do lots of formatting and propagating the allocation to a single `format!` call. 