### PR TITLE
Refine some minor things

### DIFF
--- a/src/compile-times.md
+++ b/src/compile-times.md
@@ -29,8 +29,9 @@ lld is not fully supported for use with Rust, but it should work for most use
 cases on Linux and Windows. There is a [GitHub Issue] tracking full support for
 lld.
 
-Another option is [mold], which is currently only available on Linux. It is
-specified in much the same way as lld. Simply substitute `mold` for `lld` in
+Another option is [mold], which is currently only available on Linux and macOS.
+Though as of mold 1.4.2, the support for macOS is an alpha feature.
+It is specified in much the same way as lld. Simply substitute `mold` for `lld` in
 the instructions above.
 
 [mold]: https://github.com/rui314/mold

--- a/src/linting.md
+++ b/src/linting.md
@@ -42,7 +42,7 @@ disallowed-types = ["std::collections::HashMap", "std::collections::HashSet"]
 
 Then add the following declaration to your Rust code.
 ```
-#![warn(clippy::disallowed_type)]
+#![warn(clippy::disallowed_types)]
 ```
-This is necessary because `disallowed_type` is (at the time of writing) a
+This is necessary because `disallowed_types` is (at the time of writing) a
 "nursery" (under development) lint. This may change in the future.


### PR DESCRIPTION
- https://github.com/nnethercote/perf-book/commit/d135503573ba0d54e3237fdbe2e9357d01b86214 replaced some but not all
- mention that [mold >= 1.4.1 has macOS support as an alpha feature](https://github.com/rui314/mold/releases/tag/v1.4.1)

Signed-off-by: Yuki Okushi <jtitor@2k36.org>