### PR TITLE
List Divan in benchmarking page

### DIFF
--- a/src/benchmarking.md
+++ b/src/benchmarking.md
@@ -21,13 +21,14 @@ Second, you need a way to run the workloads, which will also dictate the
 metrics used.
 - Rust's built-in [benchmark tests] are a simple starting point, but they use
   unstable features and therefore only work on Nightly Rust.
-- [Criterion] is a more sophisticated alternative.
+- [Criterion] and [Divan] are more sophisticated alternatives.
 - [Hyperfine] is an excellent general-purpose benchmarking tool.
 - Custom benchmarking harnesses are also possible. For example, [rustc-perf] is
   the harness used to benchmark the Rust compiler.
 
 [benchmark tests]: https://doc.rust-lang.org/nightly/unstable-book/library-features/test.html
 [Criterion]: https://github.com/bheisler/criterion.rs
+[Divan]: https://github.com/nvzqz/divan
 [Hyperfine]: https://github.com/sharkdp/hyperfine
 [rustc-perf]: https://github.com/rust-lang/rustc-perf/
 


### PR DESCRIPTION
[Divan](https://nikolaivazquez.com/blog/divan/) is a new alternative to Criterion with a focus on user experience by being fast to run and simple to use. It has features like [measuring allocations](https://nikolaivazquez.com/blog/divan/#measure-allocations), [measuring thread contention](https://nikolaivazquez.com/blog/divan/#measure-thread-contention), and [generic user benchmark functions](https://nikolaivazquez.com/blog/divan/#generic-benchmarks). It currently emits a compact CLI output, and will later have JSON and graph outputs.