### PR TITLE
`config.toml` -> `bootstrap.toml` when mentioning compiling stdlib

### DIFF
--- a/src/profiling.md
+++ b/src/profiling.md
@@ -74,7 +74,7 @@ Rust standard library are not built with debug info.
 
 The most reliable way around this is to build your own version of the compiler
 and standard library, following [these instructions], and adding the following
-lines to the `config.toml` file:
+lines to a `bootstrap.toml` file in the repository root:
  ```toml
 [rust]
 debuginfo-level = 1


### PR DESCRIPTION
Changes mention of `config.toml` to `bootstrap.toml` when talking about compiling Rust from source in the "Profiling" section.
Relevant PR where the default got changed: https://github.com/rust-lang/rust/pull/137081

I was trying to setup some profiling for a project I'm working on, and I was a bit confused between a `.cargo/config.toml` and a `config.toml`. It looks like they changed the name upstream in https://github.com/rust-lang/rust (citing similar reasons).